### PR TITLE
fixes the way we handle assay types in the add_genetic_id function

### DIFF
--- a/R/load-sherlock.R
+++ b/R/load-sherlock.R
@@ -51,6 +51,7 @@ generate_threshold <- function(con, plate_run_identifier, .control_id="NTC") {
 #' identification.
 #' @param con valid connection to the database
 #' @param thresholds threshold values calculated in `generate_threshold`
+#' @param plate_run_id the plate run to perform threshold calculations on
 #' @param .control_id identifier used to find the control variable
 #' @details The assay result table is updated to reflect whether the assays
 #' in a plate run produced raw fluorescence values that exceed the threshold
@@ -204,6 +205,7 @@ add_raw_assay_results <- function(con, assay_results) {
 #' sample based on assay results.
 #' @param con valid connection to database
 #' @param sample_identifiers identifiers for samples to be added
+#' @param plate_run_id plate run id to run genetic identification on
 #' @details `add_genetic_identification` checks the database for all existing
 #' assay results for a sample identifier, then uses those to assign a
 #' genetic identification value. The genetic_run_identification table in the

--- a/R/load-sherlock.R
+++ b/R/load-sherlock.R
@@ -51,7 +51,7 @@ generate_threshold <- function(con, plate_run_identifier, .control_id="NTC") {
 #' identification.
 #' @param con valid connection to the database
 #' @param thresholds threshold values calculated in `generate_threshold`
-#' @param plate_run_id the plate run to perform threshold calculations on
+#' @param plate_run_id the plate run to perform update on
 #' @param .control_id identifier used to find the control variable
 #' @details The assay result table is updated to reflect whether the assays
 #' in a plate run produced raw fluorescence values that exceed the threshold

--- a/data-raw/user-workflow.R
+++ b/data-raw/user-workflow.R
@@ -10,8 +10,8 @@ con <- gr_db_connect() # this searches for a config file, starting at the workin
 
 # check connection is working - should see head of these tables
 dbListTables(con)
-tbl(con, "agency")
-tbl(con, "status_code")
+dplyr::tbl(con, "agency")
+dplyr::tbl(con, "status_code")
 
 # assume you have added your sample plan that initialized all sample IDs you will
 # be processing - see "data-raw/user-workflow-preseason.R"
@@ -66,7 +66,7 @@ tbl(con, "plate_run")
 
 # this is for the split plate version
 # plate_map_details is a variable you will need to pass to a later function
-plate_map_details_event <- process_well_sample_details(filepath = "templates/sherlock_results_template.xlsx",
+plate_map_details_event <- process_well_sample_details(filepath = "inst/sherlock_results_template.xlsx",
                                                  sample_type = "mucus",
                                                  layout_type = "split_plate_early_late",
                                                  plate_run_id = plate_run_id_event)
@@ -77,7 +77,7 @@ plate_map_details_event <- process_well_sample_details(filepath = "templates/she
 # the generic IDs with the JPE sample IDs.
 # sherlock_results is a variable you will need to pass to a later function
 sherlock_results_event <- process_sherlock(
-  filepath = "templates/sherlock_results_template.xlsx",
+  filepath = "inst/sherlock_results_template.xlsx",
   sample_details = plate_map_details_event,
   plate_size = 384)
 
@@ -93,7 +93,7 @@ thresholds_event <- generate_threshold(con, plate_run_identifier = plate_run_id_
 
 # update assay detection results (TRUE or FALSE for a sample and assay type)
 # in the database
-update_assay_detection(con, thresholds_event)
+update_assay_detection(con, thresholds_event, plate_run_id = plate_run_id_event)
 
 # view assay results.
 # this table contains the sample IDs run, the assay type, and positive detection

--- a/man/add_genetic_identification.Rd
+++ b/man/add_genetic_identification.Rd
@@ -10,6 +10,8 @@ add_genetic_identification(con, sample_identifiers, plate_run_id)
 \item{con}{valid connection to database}
 
 \item{sample_identifiers}{identifiers for samples to be added}
+
+\item{plate_run_id}{plate run id to run genetic identification on}
 }
 \description{
 `add_genetic_identification` assigns genetic identifier to a

--- a/man/add_genetic_identification.Rd
+++ b/man/add_genetic_identification.Rd
@@ -4,7 +4,7 @@
 \alias{add_genetic_identification}
 \title{Genetic Identification}
 \usage{
-add_genetic_identification(con, sample_identifiers)
+add_genetic_identification(con, sample_identifiers, plate_run_id)
 }
 \arguments{
 \item{con}{valid connection to database}

--- a/man/update_assay_detection.Rd
+++ b/man/update_assay_detection.Rd
@@ -11,7 +11,7 @@ update_assay_detection(con, thresholds, plate_run_id, .control_id = "NTC")
 
 \item{thresholds}{threshold values calculated in `generate_threshold`}
 
-\item{plate_run_id}{the plate run to perform threshold calculations on}
+\item{plate_run_id}{the plate run to perform update on}
 
 \item{.control_id}{identifier used to find the control variable}
 }

--- a/man/update_assay_detection.Rd
+++ b/man/update_assay_detection.Rd
@@ -4,7 +4,7 @@
 \alias{update_assay_detection}
 \title{Set detection for assay results}
 \usage{
-update_assay_detection(con, thresholds, .control_id = "NTC")
+update_assay_detection(con, thresholds, plate_run_id, .control_id = "NTC")
 }
 \arguments{
 \item{con}{valid connection to the database}

--- a/man/update_assay_detection.Rd
+++ b/man/update_assay_detection.Rd
@@ -11,6 +11,8 @@ update_assay_detection(con, thresholds, plate_run_id, .control_id = "NTC")
 
 \item{thresholds}{threshold values calculated in `generate_threshold`}
 
+\item{plate_run_id}{the plate run to perform threshold calculations on}
+
 \item{.control_id}{identifier used to find the control variable}
 }
 \value{


### PR DESCRIPTION
basically we must first filter to just the plate run at hand, then we can make use of the `names_expand` argument to pivot so that we dont have to do the hacky "DELETE_ME" row. Note that to do this we must first make the assay_type into a factor to let `name_expand` know there are other values not present here that need to be expanded.

This addresses and closes #76 since we don't have a unique problem from pivot since we filter to just a plate run now.