### PR TITLE
120 status code refinements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     config,
     cli,
     progress,
-    memoise
+    tidyselect
 Depends: 
     R (>= 2.10)
 RoxygenNote: 7.2.3


### PR DESCRIPTION
refinements to the way status codes are assigned. This PR also introduces a few other changes:

1. write to genetic_id table in database whenever possible, this means we are now writting to table cases where ID = "UNK" and "SPW"
2. add two new cols to genetic_id table. To better track the path to results this adds `spring_plate_Id` and `winter_plate_id` to the table, updates in this PR include changes to support those database changes

To test, pull latest version of run-id-database and run migrations

closes #120 