### PR TITLE
Genetic Run Assignment updates

### DIFF
--- a/R/genetic-identification.R
+++ b/R/genetic-identification.R
@@ -204,7 +204,7 @@ ots_early_late_detection <- function(con, sample_id,
   }
   # positive late and positive early --> HET more testing needed
   else if (ots_early_priority_results$positive_detection && ots_late_priority_results$positive_detection) {
-    return(list(sample_id = sample_id, status_code = "analysis complete", run_type="HET", early_plate = ots_early_priority_results$plate_run_id, late_plate = ots_late_priority_results$plate_run_id))
+    return(list(sample_id = sample_id, status_code = "analysis complete", run_type="EL-HET", early_plate = ots_early_priority_results$plate_run_id, late_plate = ots_late_priority_results$plate_run_id))
   }
   # negative late and positive early --> SPW need ots 16
   else if (ots_early_priority_results$positive_detection && !ots_late_priority_results$positive_detection) {
@@ -335,7 +335,7 @@ ots_winter_spring_detection <- function(con, sample_id,
   }
   # positive winter and positive spring ---> HET
   else if (ots_spring_priority_results$positive_detection && ots_winter_priority_results$positive_detection) {
-    return(list(sample_id = sample_id, status_code = "analysis complete", run_type="HET",
+    return(list(sample_id = sample_id, status_code = "analysis complete", run_type="SW-HET",
                 winter_plate_id = ots_winter_priority_results$plate_run_id, spring_plate_id = ots_spring_priority_results$plate_run_id))
   }
   # negative winter and positive spring --> SPR

--- a/R/genetic-identification.R
+++ b/R/genetic-identification.R
@@ -84,7 +84,7 @@ add_plate_thresholds <- function(con, thresholds, .control_id = "NTC") {
 #' @export
 #' @md
 ots_early_late_detection <- function(con, sample_id,
-                                     selection_strategy = "recent priority") {
+                                     selection_strategy = c("recent priority", "positive priority")) {
 
   selection_strategy <- match.arg(selection_strategy)
 
@@ -144,6 +144,8 @@ ots_early_late_detection <- function(con, sample_id,
     if (selection_strategy == "positive priority") {
       ots_early_priority_results <-
         ots_early |> filter(positive_detection) |>
+        arrange(desc(created_at)) |>
+        head(1) |>
         collect()
       if (nrow(ots_early_priority_results) > 1) {
         cli::cli_abort(c(
@@ -604,7 +606,6 @@ parse_detection_results <- function(detection_results) {
                early_plate = x$early_plate,
                late_plate = x$late_plate)
   })
-
 }
 
 parse_spring_winter_detection_results <- function(detection_results) {
@@ -616,5 +617,4 @@ parse_spring_winter_detection_results <- function(detection_results) {
                spring_plate_id = x$spring_plate_id
     )
   })
-
 }

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -61,25 +61,28 @@ function(input, output, session) {
   observeEvent(input$do_upload, {
     tryCatch({
       #messages <- capture.output(
-        grunID::add_new_plate_results(con, protocol_name = input$protocol,
-                                           genetic_method = input$genetic_method,
-                                           laboratory = input$laboratory,
-                                           lab_work_performed_by = input$performed_by,
-                                           description = input$run_description,
-                                           date_run = input$date_run,
-                                           filepath = input$sherlock_results$datapath,
-                                           sample_type = input$sample_type,
-                                           layout_type = input$layout_type,
-                                           plate_size = input$plate_size,
-                                      .control_id = "EBK",
-                                      run_gen_id = input$perform_genetics_id)
+        grunID::add_new_plate_results(
+          con,
+          protocol_name = input$protocol,
+          genetic_method = input$genetic_method,
+          laboratory = input$laboratory,
+          lab_work_performed_by = input$performed_by,
+          description = input$run_description,
+          date_run = input$date_run,
+          filepath = input$sherlock_results$datapath,
+          sample_type = input$sample_type,
+          layout_type = input$layout_type,
+          plate_size = input$plate_size,
+          selection_strategy = "positive priority",
+          .control_id = "EBK",
+          run_gen_id = input$perform_genetics_id)
       #)
       #shinyCatch({message(paste0(messages))}, prefix = '') # this prints out messages (only at the end of the function) to shiny
       spsComps::shinyCatch({message("Success!")}, position = "top-center")},
       error = function(e) {
-          spsComps::shinyCatch({stop(paste(e))}, prefix = '', position = "top-center")
+        spsComps::shinyCatch({stop(paste(e))}, prefix = '', position = "top-center")
       })
-    }
+  }
   )
 
 

--- a/man/ots_early_late_detection.Rd
+++ b/man/ots_early_late_detection.Rd
@@ -7,7 +7,7 @@
 ots_early_late_detection(
   con,
   sample_id,
-  selection_strategy = "recent priority"
+  selection_strategy = c("recent priority", "positive priority")
 )
 }
 \arguments{


### PR DESCRIPTION
PR adds the run types for: 

- EL-HET,Early/Late Heterozygous
- SW-HET,Spring/Winter Heterozygous

Latest migration on database needed so just pull main from `run-id-database`

And new failure status codes for negative + negative results, to test this use the following:

Insert new status

```sql
insert into status_code (status_code_name, description) values ('EL-failed', 'sample identification failed at Early+Late Stage');
insert into status_code (status_code_name, description) values ('SW-failed', 'sample identification failed at Spring+Winter Stage');
```

Then upload the files in 

```
\data-raw\sherlock-example-outputs\2024\results-in-fail
```

**MIL24_1_E_1** should fail and be assigned UIKNOWN

Lastly need to temporariliy make this change in the shiny server.R file:

```r
grunID::add_new_plate_results(
          con,
          protocol_name = input$protocol,
          genetic_method = input$genetic_method,
          laboratory = input$laboratory,
          lab_work_performed_by = input$performed_by,
          description = input$run_description,
          date_run = input$date_run,
          filepath = input$sherlock_results$datapath,
          sample_type = input$sample_type,
          layout_type = input$layout_type,
          plate_size = input$plate_size,
        selection_strategy = "recent priority", # <------------ change here
          .control_id = "EBK",
          run_gen_id = input$perform_genetics_id)
```

closes #153 
closes #143 